### PR TITLE
Feature/add story background cg handler

### DIFF
--- a/Assets/Scripts/Editor/UI/BackgroundCGEditor.cs
+++ b/Assets/Scripts/Editor/UI/BackgroundCGEditor.cs
@@ -27,6 +27,8 @@ namespace StoryEditor.UI
             EditorGUILayout.Space();
             DrawImageNameSelection(backgroundCG);
             EditorGUILayout.Space();
+            DrawAnimationSettings(backgroundCG);
+            EditorGUILayout.Space();
             DrawImagePreview(backgroundCG);
         }
 
@@ -126,6 +128,58 @@ namespace StoryEditor.UI
                 var rect = GUILayoutUtility.GetRect(200, 150, GUILayout.ExpandWidth(false));
                 EditorGUI.DrawPreviewTexture(rect, selectedSprite.texture);
             }
+        }
+
+        private void DrawAnimationSettings(StoryBackgroundCG backgroundCG)
+        {
+            EditorGUILayout.BeginHorizontal();
+            EditorGUILayout.LabelField("Animation:", EditorStyles.boldLabel, GUILayout.Width(120));
+            
+            var animationTypes = System.Enum.GetValues(typeof(StoryBackgroundCG.BackgroundAnimationType))
+                .Cast<StoryBackgroundCG.BackgroundAnimationType>()
+                .Where(type => type != StoryBackgroundCG.BackgroundAnimationType.BackgroundAnimtationTypeCount)
+                .ToArray();
+            var animationNames = animationTypes.Select(type => type.ToString()).ToArray();
+            
+            var currentIndex = System.Array.IndexOf(animationTypes, backgroundCG.Animation);
+            var newIndex = EditorGUILayout.Popup(currentIndex, animationNames, GUILayout.Width(150));
+            
+            if (newIndex != currentIndex && 0 <= newIndex && newIndex < animationTypes.Length)
+            {
+                backgroundCG.Animation = animationTypes[newIndex];
+            }
+            
+            EditorGUILayout.EndHorizontal();
+
+            EditorGUILayout.BeginHorizontal();
+            EditorGUILayout.LabelField("Duration:", EditorStyles.boldLabel, GUILayout.Width(120));
+            
+            var newDuration = EditorGUILayout.FloatField(backgroundCG.AnimationDuration, GUILayout.Width(80));
+            if (newDuration != backgroundCG.AnimationDuration && 0 < newDuration)
+            {
+                backgroundCG.AnimationDuration = newDuration;
+            }
+            
+            EditorGUILayout.EndHorizontal();
+
+            EditorGUILayout.BeginHorizontal();
+            EditorGUILayout.LabelField("Target Position:", EditorStyles.boldLabel, GUILayout.Width(120));
+            
+            var positionTypes = System.Enum.GetValues(typeof(StoryBackgroundCG.BackgroundPositionType))
+                .Cast<StoryBackgroundCG.BackgroundPositionType>()
+                .Where(type => type != StoryBackgroundCG.BackgroundPositionType.BackgroundPositionTypeCount)
+                .ToArray();
+            var positionNames = positionTypes.Select(type => type.ToString()).ToArray();
+            
+            var currentPosIndex = System.Array.IndexOf(positionTypes, backgroundCG.TargetPosition);
+            var newPosIndex = EditorGUILayout.Popup(currentPosIndex, positionNames, GUILayout.Width(100));
+            
+            if (newPosIndex != currentPosIndex && 0 <= newPosIndex && newPosIndex < positionTypes.Length)
+            {
+                backgroundCG.TargetPosition = positionTypes[newPosIndex];
+            }
+            
+            EditorGUILayout.EndHorizontal();
         }
     }
 }

--- a/Assets/Scripts/GameData/Story/Script/StoryBackgroundCG.cs
+++ b/Assets/Scripts/GameData/Story/Script/StoryBackgroundCG.cs
@@ -8,60 +8,42 @@ namespace AD.Story
     {
         /****** Public Members ******/
 
-        public enum AnimationType
+        public enum BackgroundAnimationType
         {
             Appear,
-            Disappear,
             Move,
             Shake,
             ZoomIn,
             ZoomOut,
-            AnimtationTypeCount
+            BackgroundAnimtationTypeCount
         }
 
-        public enum TargetPositionType
+        public enum BackgroundPositionType
         {
             Center = 0,
             Left,
             Right,
-            TargetPositionTypeCount
+            BackgroundPositionTypeCount
         }
-
-        public ChapterType          Chapter             => _chapter;
-        public string               ImageName           => _imageName;
-        public AnimationType        Animation           => _animation;
-        public float                AnimationDuration   => _animationDuration;
-        public TargetPositionType   TargetPosition      => _targetPosition;
-
-        public override bool        IsSavePoint => false;
-        public override EntryType   Type        => EntryType.BackgroundCG;
 
         public StoryBackgroundCG()
         {
-            
+            Type = EntryType.BackgroundCG;
         }
 
-        public StoryBackgroundCG(ChapterType chapter, string imageName, AnimationType animation = AnimationType.Appear, float animationDuration = 1.0f, TargetPositionType targetPosition = TargetPositionType.Center)
-        {
-            Debug.Assert(ChapterType.ChapterTypeCount != chapter, "ChapterType must be set to a valid chapter.");
-            Debug.Assert(false == string.IsNullOrEmpty(imageName), "ImageName must not be empty or null.");
-            Debug.Assert(AnimationType.AnimtationTypeCount != animation, "AnimationType must be set to a valid animation type.");
-            Debug.Assert(0 < animationDuration, "AnimationDuration must be greater than zero.");
+        [XmlAttribute("Chapter")]
+        public ChapterType Chapter = ChapterType.ChapterTypeCount;
+        
+        [XmlAttribute("ImageName")]
+        public string ImageName = "";
 
-            _chapter            = chapter;
-            _imageName          = imageName;
-            _animation          = animation;
-            _animationDuration  = animationDuration;
-            _targetPosition     = targetPosition;
-        }
+        [XmlAttribute("Animation")]
+        public BackgroundAnimationType Animation = BackgroundAnimationType.Appear;
 
+        [XmlAttribute("AnimationDuration")]
+        public float AnimationDuration = 1.0f;
 
-        /****** Private Members ******/
-
-        [XmlAttribute("Chapter")]           private     ChapterType         _chapter            = ChapterType.ChapterTypeCount;
-        [XmlAttribute("ImageName")]         private     string              _imageName          = "";
-        [XmlAttribute("Animation")]         private     AnimationType       _animation          = AnimationType.AnimtationTypeCount;
-        [XmlAttribute("AnimationDuration")] private     float               _animationDuration  = 1.0f;
-        [XmlAttribute("TargetPosition")]    private     TargetPositionType  _targetPosition     = TargetPositionType.TargetPositionTypeCount;
+        [XmlAttribute("TargetPosition")]
+        public BackgroundPositionType TargetPosition = BackgroundPositionType.Center;
     }
 }

--- a/Assets/Scripts/GameData/Story/Script/StoryBackgroundCG.cs
+++ b/Assets/Scripts/GameData/Story/Script/StoryBackgroundCG.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Xml.Serialization;
 
 namespace AD.Story
@@ -5,15 +6,62 @@ namespace AD.Story
     [System.Serializable]
     public class StoryBackgroundCG : StoryEntry
     {
-        public StoryBackgroundCG() 
+        /****** Public Members ******/
+
+        public enum AnimationType
         {
-            Type = EntryType.BackgroundCG;
+            Appear,
+            Disappear,
+            Move,
+            Shake,
+            ZoomIn,
+            ZoomOut,
+            AnimtationTypeCount
         }
 
-        [XmlAttribute("Chapter")]
-        public ChapterType Chapter;
+        public enum TargetPositionType
+        {
+            Center = 0,
+            Left,
+            Right,
+            TargetPositionTypeCount
+        }
 
-        [XmlAttribute("ImageName")]
-        public string ImageName;
+        public ChapterType          Chapter             => _chapter;
+        public string               ImageName           => _imageName;
+        public AnimationType        Animation           => _animation;
+        public float                AnimationDuration   => _animationDuration;
+        public TargetPositionType   TargetPosition      => _targetPosition;
+
+        public override bool        IsSavePoint => false;
+        public override EntryType   Type        => EntryType.BackgroundCG;
+
+        public StoryBackgroundCG()
+        {
+            
+        }
+
+        public StoryBackgroundCG(ChapterType chapter, string imageName, AnimationType animation = AnimationType.Appear, float animationDuration = 1.0f, TargetPositionType targetPosition = TargetPositionType.Center)
+        {
+            Debug.Assert(ChapterType.ChapterTypeCount != chapter, "ChapterType must be set to a valid chapter.");
+            Debug.Assert(false == string.IsNullOrEmpty(imageName), "ImageName must not be empty or null.");
+            Debug.Assert(AnimationType.AnimtationTypeCount != animation, "AnimationType must be set to a valid animation type.");
+            Debug.Assert(0 < animationDuration, "AnimationDuration must be greater than zero.");
+
+            _chapter            = chapter;
+            _imageName          = imageName;
+            _animation          = animation;
+            _animationDuration  = animationDuration;
+            _targetPosition     = targetPosition;
+        }
+
+
+        /****** Private Members ******/
+
+        [XmlAttribute("Chapter")]           private     ChapterType         _chapter            = ChapterType.ChapterTypeCount;
+        [XmlAttribute("ImageName")]         private     string              _imageName          = "";
+        [XmlAttribute("Animation")]         private     AnimationType       _animation          = AnimationType.AnimtationTypeCount;
+        [XmlAttribute("AnimationDuration")] private     float               _animationDuration  = 1.0f;
+        [XmlAttribute("TargetPosition")]    private     TargetPositionType  _targetPosition     = TargetPositionType.TargetPositionTypeCount;
     }
 }


### PR DESCRIPTION
BackgroundCG에 적용될 애니메이션 관련 속성을 추가했습니다.

- Appear : AnimationDuration이 0보다 크면, alpha 값이 0에서 1로 증가하며 서서히 증가합니다.
- Move : TargePosition 방향으로 '카메라'가 이동합니다. right이면 배경 화면의 오른쪽 부분이 보여져야 합니다.
- ZoomIn/ZoomOut : TargetPosition 방향을 중심으로 하여 확대와 축소를 진행합니다. 확대와 축소의 정도는 일단 특정 수치로 고정하려고 합니다.
- Shake : 배경 화면이 흔들립니다. 원래는 카메라를 흔들려고 했는데, Background가 UI의 일부가 되면서 이미지 자체를 흔들어야 할 것 같습니다.

요구되는 애니메이션위 위 목록과 같고, 머지 이후 현재 브랜치에서 이어서 작업하셔도 될 듯 합니다.