### PR TITLE
feature/modified story system UI

### DIFF
--- a/Assets/GameResources/Prefab/UI/Story/StoryUI.prefab
+++ b/Assets/GameResources/Prefab/UI/Story/StoryUI.prefab
@@ -615,7 +615,7 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3161604632494318567}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -933,9 +933,9 @@ RectTransform:
   m_Children:
   - {fileID: 1076447538901041581}
   - {fileID: 1802619896256497624}
-  - {fileID: 152405718543298927}
   - {fileID: 4131841511543440235}
   - {fileID: 7243728122638718034}
+  - {fileID: 152405718543298927}
   - {fileID: 5768379830061225198}
   - {fileID: 4007610472625469069}
   m_Father: {fileID: 0}
@@ -1436,6 +1436,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 3941231010492196472}
     m_Modifications:
+    - target: {fileID: 808939818406593077, guid: d0e37436623c54534829cb25e94ea8e4, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 5
+      objectReference: {fileID: 0}
     - target: {fileID: 1849939611678302816, guid: d0e37436623c54534829cb25e94ea8e4, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
@@ -1516,9 +1520,37 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1963100585341502849, guid: d0e37436623c54534829cb25e94ea8e4, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 4000
+      objectReference: {fileID: 0}
+    - target: {fileID: 1963100585341502849, guid: d0e37436623c54534829cb25e94ea8e4, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 5500
+      objectReference: {fileID: 0}
+    - target: {fileID: 1963100585341502849, guid: d0e37436623c54534829cb25e94ea8e4, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1963100585341502849, guid: d0e37436623c54534829cb25e94ea8e4, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -100
+      objectReference: {fileID: 0}
     - target: {fileID: 6606582413633410694, guid: d0e37436623c54534829cb25e94ea8e4, type: 3}
       propertyPath: m_Name
       value: CharacterCGHolder
+      objectReference: {fileID: 0}
+    - target: {fileID: 6906099347969535457, guid: d0e37436623c54534829cb25e94ea8e4, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8459179483110864602, guid: d0e37436623c54534829cb25e94ea8e4, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 5500
+      objectReference: {fileID: 0}
+    - target: {fileID: 8967392415469307073, guid: d0e37436623c54534829cb25e94ea8e4, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -1749,6 +1781,10 @@ PrefabInstance:
     - target: {fileID: 7644084321292910779, guid: f97915835bc86b749b13fe9f29dd6192, type: 3}
       propertyPath: m_Name
       value: Pnl_DialogueBox
+      objectReference: {fileID: 0}
+    - target: {fileID: 8969400963482401064, guid: f97915835bc86b749b13fe9f29dd6192, type: 3}
+      propertyPath: m_Maskable
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Scripts/Event/Events/Input Events/NextScriptEvent.cs
+++ b/Assets/Scripts/Event/Events/Input Events/NextScriptEvent.cs
@@ -19,7 +19,7 @@ public class NextScriptEvent : InputEvent, KeySettingsObserver
     // Detect if event button is pressed or panel is clicked
     public override bool DetectInput()
     {
-        bool buttonClicked = Input.GetKeyDown(eventButton);
+        bool buttonClicked = Input.GetKeyDown(eventButton) || Input.GetKeyDown(KeyCode.Space);
         bool panelClicked = UIController.Instance.IsStoryPanelClicked;
         return buttonClicked || panelClicked;
     }


### PR DESCRIPTION
Notion의 **스토리 시스템 UI 기능 수정**의 요청사항을 반영한 branch 입니다.
변경사항은 매우 적습니다.

**StoryUI.prefab 수정에 대하여**
- Pnl_DialogueBox와 Click Panel의 Hierachy의 배치 순서를 바꿨습니다. DialougueBox의 `Maskable`을 비활성화해도 원하는대로 동작하지 않아 Click Panel의 layer가 DialougueBox 위에 배치되도록 했습니다.
- CharacterCGView의 RectTransform.Height를 4500에서 5500으로 늘렸습니다.

**NextScriptEvent.cs 수정에 대하여**
- DetectInput()의 buttonClicked가 Input.GetKeyDown(KeyCode.Space)를 합연산한 결과를 나타냅니다.